### PR TITLE
Speed-Up build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install udata and all known plugins
-COPY requirements.pip /tmp/requirements.pip
+ADD requirements.pip /tmp/requirements.pip
 RUN pip install -r /tmp/requirements.pip
 
 RUN mkdir -p /udata/fs /src


### PR DESCRIPTION
Using `ADD` instead of `COPY` for Python `requirements` file speed-up significally build phase. If no changes are detected on requirements file, docker use cache.