### PR TITLE
Migrate requirements to udata 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Check that [`localhost.local:7000`](http://localhost.local:7000) is available in
 
 ## Details
 
-This Docker image provide udata as well as all known plugins and themes.
+This Docker image provide udata as well as known plugins and gouvfr theme.
 
 It is packaged to run within uwsgi with gevent support.
 
@@ -116,6 +116,8 @@ docker run [DOCKER OPTIONS] udata/udata bash
 ```
 
 ## Installing extra sources
+
+:warning: theme management have been modified when [migrating to udata 3](https://udata.readthedocs.io/en/stable/roadmap/udata-3/). This section is under renovation.
 
 You can install extra sources by mounting directories as subdirectories of `/src/`.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ docker run [DOCKER OPTIONS] udata/udata bash
 
 ## Installing extra sources
 
-:warning: theme management have been modified when [migrating to udata 3](https://udata.readthedocs.io/en/stable/roadmap/udata-3/). This section is under renovation.
+:warning: Theme management has been modified when [migrating to udata 3](https://udata.readthedocs.io/en/stable/roadmap/udata-3/). This section is under renovation.
 
 You can install extra sources by mounting directories as subdirectories of `/src/`.
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,11 +1,10 @@
 uwsgi==2.0.19.1
 gevent==20.9.0
-raven==6.10.0
-udata==2.4.1
+udata==3.3.2
 udata-ckan==2.0.0
-udata-croquemort==2.0.1
 udata-geoplatform==2.0.0
-udata-gouvfr==2.2.3
+udata-front==1.2.4
 udata-ods==2.1.0
-udata-piwik==2.1.2
-udata-recommendations==2.1.1
+udata-piwik==3.1.0
+udata-recommendations==3.1.0
+sentry-sdk[flask]==1.3.1

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,5 +1,5 @@
-uwsgi==2.0.19.1
-gevent==20.9.0
+uwsgi==2.0.20
+gevent==21.12.0
 udata==3.3.2
 udata-ckan==2.0.0
 udata-geoplatform==2.0.0

--- a/samples/gouvfr/udata.cfg
+++ b/samples/gouvfr/udata.cfg
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 DEBUG = False

--- a/samples/theme/udata.cfg
+++ b/samples/theme/udata.cfg
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 DEBUG = True

--- a/udata.cfg
+++ b/udata.cfg
@@ -1,8 +1,12 @@
+# -*- coding: utf-8 -*-
 from udata.settings import Defaults
 
 DEBUG = False
 
 MONGODB_HOST = 'mongodb://mongodb:27017/udata'
+
+PLUGINS = ['front']
+THEME = 'gouvfr'
 
 ELASTICSEARCH_URL = 'elasticsearch:9200'
 

--- a/udata.cfg
+++ b/udata.cfg
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from udata.settings import Defaults
 
 DEBUG = False


### PR DESCRIPTION
Use udata 3 requirements and add a default front plugin using gouvfr front.

Fix all requirements update:
- close https://github.com/opendatateam/docker-udata/pull/262
- close https://github.com/opendatateam/docker-udata/pull/260
- close https://github.com/opendatateam/docker-udata/pull/256
- close https://github.com/opendatateam/docker-udata/pull/255
- close https://github.com/opendatateam/docker-udata/pull/253
- close https://github.com/opendatateam/docker-udata/pull/250