### PR TITLE
Add circle ci config with docker build and push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,15 @@ jobs:
           version: 20.10.11
           docker_layer_caching: true
       - run:
-          name: Build a distributable package
+          name: Build and push docker image
           command: |
             TAG=1.7.$CIRCLE_BUILD_NUM
             docker build \
               --build-arg REVISION=`git rev-parse --short HEAD` \
               --build-arg CREATED=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
               -t udata/udata:$TAG .
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker push udata/udata:$TAG
       - store_artifacts:
           path: dist
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,11 @@ jobs:
       - run:
           name: Build and push docker image
           command: |
-            TAG=1.7.$CIRCLE_BUILD_NUM
+            if [[ $CIRCLE_TAG ]]; then
+                # This is a tagged release
+                TAG=$CIRCLE_TAG
+            else
+                TAG=latest
             docker build \
               --build-arg REVISION=`git rev-parse --short HEAD` \
               --build-arg CREATED=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
@@ -37,7 +41,6 @@ workflows:
               only:
                 - master
                 - /[0-9]+(\.[0-9]+)+/
-                - feat/add-docker-push-ci  # TODO: remove this temporary branch trigger
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ version: 2
 jobs:
   publish-docker-image:
     docker:
-      - image: udata/circleci:2-alpine
+      - image: cimg/base:stable-20.04
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.11
           docker_layer_caching: true
       - run:
           name: Build a distributable package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+---
+version: 2
+
+jobs:
+  publish-docker-image:
+    docker:
+      - image: udata/circleci:2-alpine
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+          docker_layer_caching: true
+      - run:
+          name: Build a distributable package
+          command: |
+            TAG=1.7.$CIRCLE_BUILD_NUM
+            docker build \
+              --build-arg REVISION=`git rev-parse --short HEAD` \
+              --build-arg CREATED=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+              -t udata/udata:$TAG .
+      - store_artifacts:
+          path: dist
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - publish-docker-image:
+          filters:
+            branches:
+              only:
+                - master
+                - /[0-9]+(\.[0-9]+)+/
+                - feat/add-docker-push-ci  # TODO: remove this temporary branch trigger
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+          context: org-global

--- a/samples/gouvfr/udata.cfg
+++ b/samples/gouvfr/udata.cfg
@@ -5,7 +5,7 @@ DEBUG = False
 MONGODB_HOST = 'mongodb://mongodb:27017/udata'
 
 DEFAULT_LANGUAGE = 'fr'
-PLUGINS = ['gouvfr']
+PLUGINS = ['front']
 THEME = 'gouvfr'
 
 
@@ -13,7 +13,7 @@ ELASTICSEARCH_URL = 'elasticsearch:9200'
 
 CACHE_TYPE = 'redis'
 CACHE_REDIS_URL = 'redis://redis:6379/1'
-BROKER_URL = 'redis://redis:6379'
+CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'
 
 FS_PREFIX = '/s'

--- a/samples/theme/udata.cfg
+++ b/samples/theme/udata.cfg
@@ -11,5 +11,5 @@ ELASTICSEARCH_URL = 'elasticsearch:9200'
 
 CACHE_TYPE = 'redis'
 CACHE_REDIS_URL = 'redis://redis:6379/1'
-BROKER_URL = 'redis://redis:6379'
+CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'


### PR DESCRIPTION
Add a ci to build and push udata docker image. Based on [https://circleci.com/docs/2.0/building-docker-images/](circle ci documentation).

This job is executed only on git tags and commits on master.
In case of a git tag, the tag is used for the docker image. In case of a master commit, the `latest` tag is used.

- [ ] Remove tag 1.7.3 created for this test: https://hub.docker.com/r/udata/udata/tags.