### PR TITLE
Changes for theme development

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,18 @@ docker run [DOCKER OPTIONS] udata/udata bash
 
 ## Installing extra sources
 
-:warning: Theme management has been modified when [migrating to udata 3](https://udata.readthedocs.io/en/stable/roadmap/udata-3/). This section is under renovation.
+:warning: Theme management has been modified when [migrating to udata 3](https://udata.readthedocs.io/en/stable/roadmap/udata-3/). You can see how to make a custom theme on [udata documentation](https://udata.readthedocs.io/en/stable/creating-theme/).
+
+See the `sample/theme` directory to see a full theme development using `docker-compose`.
 
 You can install extra sources by mounting directories as subdirectories of `/src/`.
 
 Given you have a udata theme `awesome-theme` in `my-theme` directory
 and you want to use docker to hack on it with live reload,
-you need to have the following line in your `udata.cfg`:
+you need to have the following lines in your `udata.cfg`:
 
 ```python
+PLUGINS = ['my-theme']
 THEME = 'awesome-theme'
 ```
 
@@ -135,8 +138,6 @@ Then you can run the udata Development server with:
 docker run -it -v `$PWD`/my-theme:/src/my-theme -v `$PWD`/udata.cfg:/udata/udata.cfg --rm udata/udata serve
 ```
 Your theme will be installed and activated.
-
-See the `sample/theme` directory to see a full theme development using `docker-compose`.
 
 # Examples
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     links:
       - mongodb:mongodb
       - redis:redis
+    command: serve --host 0.0.0.0 --debugger --reload
     volumes:
       - udata-fs:/udata/fs
     ports:

--- a/samples/theme/README.md
+++ b/samples/theme/README.md
@@ -1,6 +1,32 @@
-# udata theme development environement with docker-compose
+# udata theme development environment with docker-compose
 
-A sample docker-compose project using a custom theme mounted in `/src/`
+A sample docker-compose project using a custom theme mounted in `/src/`.
+
+You **must** replace `my-theme` folder with your [independent plugin theme](https://udata.readthedocs.io/en/stable/creating-theme/#independent-plugin-theme) or your [udata-front based theme](https://udata.readthedocs.io/en/stable/creating-theme/#udata-front-based-theme-not-recommended).
+
+You should build your own udata image instead of using `udata/udata` for now.
+
+
+## independent plugin theme
+
+If you are using an independent plugin theme, you must activate your plugin and your theme. 
+If you don't activate any plugin, your udata setup won't have any user facing view.
+
+```
+PLUGINS = ["my-plugin"]
+THEME = 'my-theme'
+```
+
+## udata-front based theme
+
+If you are using a udata-front based theme, you must activate the front plugin and your theme :
+
+```
+PLUGINS = ["front"]
+THEME = 'gouvfr'
+```
+
+
 
 ```bash
 $ docker-compose up -d

--- a/samples/theme/README.md
+++ b/samples/theme/README.md
@@ -26,6 +26,14 @@ PLUGINS = ["front"]
 THEME = 'gouvfr'
 ```
 
+The default `entrypoint.sh` won't work with udata-front requirements folder so a custom one is provided here. It should be added to the service volumes as shown below:
+
+```
+volumes:
+    - ./udata.cfg:/udata/udata.cfg
+    - ./udata-front-entrypoint.sh:/udata/entrypoint.sh
+    - ./udata_front:/src/udata_front
+```
 
 
 ```bash

--- a/samples/theme/docker-compose.yml
+++ b/samples/theme/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - "9200:9200"
 
   udata:
-    image: udata/udata
-    command: serve --host 0.0.0.0
+    build: ../../
+    command: serve --host 0.0.0.0 --debugger --reload
     links:
       - mongodb:mongodb
       - redis:redis

--- a/samples/theme/udata-front-entrypoint.sh
+++ b/samples/theme/udata-front-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+if [ "$(ls -A /src)" ]; then
+    # Install source repositories as editable
+    for d in /src/*/ ; do
+        echo "Installing $d"
+        pip install -e "$d"
+    done
+fi
+
+case $1 in
+    uwsgi)
+        udata collect -ni /udata/public
+        uwsgi --emperor /udata/uwsgi/
+        ;;
+    front)
+        uwsgi /udata/uwsgi/front.ini
+        ;;
+    worker)
+        uwsgi /udata/uwsgi/worker.ini
+        ;;
+    beat)
+        uwsgi /udata/uwsgi/beat.ini
+        ;;
+    celery)
+        celery -A udata.worker "${@:2}"
+        ;;
+    bash)
+        /bin/bash
+        ;;
+    *)
+        udata "$@"
+        ;;
+esac


### PR DESCRIPTION
This PR updates READMEs to better document how to use docker-udata for theme development.

Also, the docker-compose files are fixed to serve static files from theme.