### PR TITLE
Updates deps and image to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for udata
 ##########################################
 
-FROM udata/system
+FROM udata/system:py3.11
 
 # Optionnal build arguments
 ARG REVISION="N/A"

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,10 +1,8 @@
-uwsgi==2.0.20
-gevent==21.12.0
-udata==7.0.4
-udata-ckan==3.0.2
-udata-geoplatform==2.0.0
-udata-front==3.5.3
-udata-ods==4.0.0
-udata-piwik==4.0.0
+uwsgi==2.0.21
+gevent==24.2.1
+udata==8.0.0
+udata-ckan==3.0.3
+udata-front==4.0.0
+udata-piwik==4.1.0
 udata-recommendations==3.1.5
-sentry-sdk[flask]==1.3.1
+sentry-sdk[flask]==1.9.0


### PR DESCRIPTION
This PR also removes archived udata plugins.

We can switch back to `udata/system` when it's updated to python 3.11.