### PR TITLE
Use debug mode for udata and flask

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - mongodb:mongodb
       - redis:redis
     command: serve --host 0.0.0.0 --debugger --reload
+    environment:
+      - FLASK_DEBUG=true
     volumes:
       - udata-fs:/udata/fs
     ports:

--- a/udata.cfg
+++ b/udata.cfg
@@ -1,6 +1,6 @@
 from udata.settings import Defaults
 
-DEBUG = False
+DEBUG = True
 
 MONGODB_HOST = 'mongodb://mongodb:27017/udata'
 


### PR DESCRIPTION
The docker-compose is in a strange mode right now :
- udata serve is launched with a debugger flag so it's not using the `DEBUG` variable from `udata.cfg`
- in `udata.cfg`, the DEBUG is set to False (but this is bypassed)
- Flask is not in debug mode so assets are not served

This PR adds the `FLASK_DEBUG=true` environment to have assets served by the udata development server.

`udata.cfg` is updated to `DEBUG = True` to make it explicit that this is mean for development and debug only.